### PR TITLE
Fix HTTP error message building

### DIFF
--- a/src/Helpers/Http.php
+++ b/src/Helpers/Http.php
@@ -49,7 +49,9 @@ class Http
         $content = @file_get_contents($this->url, false, $context);
 
         if ($content === false) {
-            throw new Exceptions\CoreException(error_get_last()['message']);
+            $error = error_get_last();
+            $message = $error === null || array_key_exists('message', $error) === false ? 'HTTP failed' : $error['message'];
+            throw new Exceptions\CoreException($message);
         }
 
         $this->content = $content;


### PR DESCRIPTION
If connection fails then sometimes there is no message and code crashes.

`error_get_last` can return null. Today CNB API sometimes resets the connection and code crashes.

- bug fix? yes/
- new feature? no
- BC break? no
